### PR TITLE
Switch to proper class name per command class

### DIFF
--- a/commands/commands/exec.js
+++ b/commands/commands/exec.js
@@ -2,7 +2,7 @@ const Command = require('../../classes/Command');
 const exec = require("util").promisify(require("child_process").exec);
 const { MessageAttachment } = require("discord.js");
 
-module.exports = class EvalCommand extends Command {
+module.exports = class ExecCommand extends Command {
 	constructor(client) {
 		super(client, {
 			name: 'exec',

--- a/commands/commands/fixdb.js
+++ b/commands/commands/fixdb.js
@@ -3,7 +3,7 @@ const { MessageAttachment: Attachment } = require('discord.js');
 const Command = require('./../../classes/Command.js');
 const safeEval = require('safe-eval')
 
-module.exports = class EvalCommand extends Command {
+module.exports = class FixdbCommand extends Command {
 	constructor(client) {
 		super(client, {
 			name: 'fixdb',

--- a/commands/commands/reboot.js
+++ b/commands/commands/reboot.js
@@ -1,7 +1,7 @@
 const Command = require("../../classes/Command");
 const write = require("util").promisify(require("fs").writeFile);
 
-module.exports = class EvalCommand extends Command {
+module.exports = class RebootCommand extends Command {
   constructor(client) {
     super(client, {
       name: "reboot",

--- a/commands/util/stats.js
+++ b/commands/util/stats.js
@@ -4,7 +4,7 @@ const moment = require("moment");
 const Embed = require("../../classes/Embed");
 require("moment-duration-format");
 
-module.exports = class EvalCommand extends Command {
+module.exports = class StatsCommand extends Command {
   constructor(client) {
     super(client, {
       name: "stats",


### PR DESCRIPTION
Changes the leftover eval class name to use a new class name for the commands
